### PR TITLE
Fix index page to display third artist's tattoos properly

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -274,7 +274,11 @@
                         </div>
                         <div class="artist-works">
                             <div class="works-slider">
-                                <div class="work-item">
+                                <div v-for="tattoo in getArtistTattoos(artist.artist_id)" :key="tattoo.tattoo_id"
+                                    class="work-item">
+                                    <img :src="tattoo.file_path" :alt="tattoo.title">
+                                </div>
+                                <div v-if="getArtistTattoos(artist.artist_id).length === 0" class="work-item">
                                     <img src="images/portfolio-2.jpg" alt="Default artwork">
                                 </div>
                             </div>


### PR DESCRIPTION
This commit resolves the issue where the third artist's tattoos weren't displaying on the index page. The problem was caused by incomplete pagination handling in the homepage's fetchTattoos function. Similar to the previous fix for the artist dashboard, we've implemented proper pagination support to fetch tattoos across all pages from the API. Additionally, we've added a dedicated getArtistTattoos method to standardize how tattoos are filtered by artist, ensuring consistent ID comparison by converting all IDs to numbers. The carousel and artist gallery sections now display tattoos from all artists correctly, including the previously missing third artist's works.